### PR TITLE
Corregido Readme luego de mover de /docs a raiz

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ y redireccionada desde:
 
 ## Instrucciones para actualizar la página web
 
-Cualquier commit en el directorio _docs_ se auto-publica en la página al hacer push a la rama _master_. GitHub se encarga de ese proceso.
+Cualquier commit en el directorio raíz se auto-publica en la página al hacer push a la rama _master_. GitHub se encarga de ese proceso.
 
 Para visualizar los cambios de manera local, se debe instalar Jekyll. El archivo [Gemfile](docs/Gemfile) lo hace bastante fácil:
 
@@ -19,12 +19,12 @@ Para visualizar los cambios de manera local, se debe instalar Jekyll. El archivo
 
 $ apt-get install bundler
 $ git clone git@github.com:algoritmos-rw/algo2
-$ cd algo2/docs
+$ cd algo2
 $ bundle install --path=../gems
 
 # Para visualizar al editar
 
-$ cd algo2/docs
+$ cd algo2
 $ bundle exec jekyll serve --livereload
 ```
 


### PR DESCRIPTION
Despues de 05446d023e76b3986e006fdfb14adbfb74c96809 quedó desactualizado el readme