### PR TITLE
Corrijo ejemplo de iterador y agrego comentario

### DIFF
--- a/static/06_faq.md
+++ b/static/06_faq.md
@@ -367,7 +367,9 @@ estructura_iter_destruir(iter);
 O usando la sintaxis de ciclos definidos de C:
 
 ``` cpp
-for(estructura_iter_t* iter = estructura_iter_crear(estructura);
+estructura_iter_t* iter;
+
+for(iter = estructura_iter_crear(estructura);
   !estructura_iter_al_final(iter);
   estructura_iter_avanzar(iter))
 {
@@ -375,8 +377,10 @@ for(estructura_iter_t* iter = estructura_iter_crear(estructura);
     /* Usar dato. */
 }
 
-  estructura_iter_destruir(iter);
+estructura_iter_destruir(iter);
 ```
+
+Se debe tener en cuenta que si bien `estructura_iter_t* iter` puede ser inicializado en el `for` (como en el ejemplo) o fuera del mismo (al ser declarada la variable), la declaración debe estar siempre fuera del `for` para no perder la referencia y poder de esta forma destruirlo cuando se termina de iterar.
 
 ### Una vez que se llega al fin, ¿El iterador no sirve más?
 


### PR DESCRIPTION
Actualmente estaba el siguiente ejemplo:

``` cpp
for(estructura_iter_t* iter = estructura_iter_crear(estructura);
  !estructura_iter_al_final(iter);
  estructura_iter_avanzar(iter))
{
    void* dato = estructura_iter_ver_actual(iter);
    /* Usar dato. */
}

  estructura_iter_destruir(iter);
```

Pero el problema es que no compila porque se declara el iterador dentro del for y después se lo intenta destruir por fuera (donde se ya perdió la referencia).

Lo reemplacé por el siguiente ejemplo:

``` cpp
estructura_iter_t* iter;

for(iter = estructura_iter_crear(estructura);
  !estructura_iter_al_final(iter);
  estructura_iter_avanzar(iter))
{
    void* dato = estructura_iter_ver_actual(iter);
    /* Usar dato. */
}

estructura_iter_destruir(iter);
```

Y también dejé la siguiente aclaración:

> Se debe tener en cuenta que si bien `estructura_iter_t* iter` puede ser inicializado en el `for` (como en el ejemplo) o fuera del mismo (al ser declarada la variable), la declaración debe estar siempre fuera del `for` para no perder la referencia y poder de esta forma destruirlo cuando se termina de iterar.