### PR TITLE
Elimino link en el espacio siguiente a la fecha de un post

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -44,6 +44,11 @@
   display: inline;
 }
 
+a.post-link:hover,
+a.post-link:focus {
+  display: inline-block;
+}
+
 .table-borderless > tbody > tr > td,
 .table-borderless > tbody > tr > th,
 .table-borderless > tfoot > tr > td,


### PR DESCRIPTION
Antes:

![image](https://user-images.githubusercontent.com/5757489/31589560-32886e3e-b1da-11e7-917d-892bc2c872db.png)

Después:

![image](https://user-images.githubusercontent.com/5757489/31589564-4f33099a-b1da-11e7-8757-468074e58f00.png)
