### PR TITLE
Fix color del -g como flag de compilación introducido en #47.

### DIFF
--- a/static/tps/2017_2/tp1/index.md
+++ b/static/tps/2017_2/tp1/index.md
@@ -443,7 +443,7 @@ El corrector automático va a interpretar ese archivos de dependencias y va a
 compilar todos los `.o` especificados a partir de los `.h` y `.c` que deberán
 enviar, con los siguientes flags de GCC:
 
-``` makefile
+```
 -g -std=c99 -Wall -Wtype-limits -pedantic -Wconversion -Wno-sign-conversion
 ```
 


### PR DESCRIPTION
Antes:
![image](https://user-images.githubusercontent.com/5757489/31981055-f923a8da-b926-11e7-9684-471fb6ca705d.png)

Después:
![image](https://user-images.githubusercontent.com/5757489/31981069-13e0de7c-b927-11e7-9a89-341067e33fee.png)
