### PR TITLE
Modificacion para tener el menu fixed y que baje con el scroll

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -227,7 +227,7 @@ DEPENDENCIES
   jekyll-livereload
 
 RUBY VERSION
-   ruby 2.3.3p222
+   ruby 2.3.5p376
 
 BUNDLED WITH
-   1.15.3
+   1.15.4

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -35,9 +35,29 @@
   }
 }
 
+.navbar {
+  position:fixed;
+  width:100%;
+  top:0px;left:0px;
+  box-shadow: 0px 2px 18px 0px rgba(0,0,0,0.15);
+}
+
 .collapse.navbar-collapse[aria-expanded="false"] {
   padding-left: 0px;
   padding-right: 0px;
+}
+
+.navbar-toggle[aria-expanded="true"] .icon-bar{
+  display:none;
+}
+
+.navbar-toggle[aria-expanded="true"]:after {
+  content:"🞫";
+  color:#888;
+}
+
+.page-content{
+  padding-top:50px; /*Padding por el navbar fixed */
 }
 
 .page-content p {
@@ -70,10 +90,6 @@ pre code {
 .table-borderless > thead > tr > td,
 .table-borderless > thead > tr > th {
     border: none;
-}
-
-.navbar {
-  margin-bottom: 0!important;
 }
 
 .navbar .dropdown-menu li {

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -39,7 +39,7 @@
   position:fixed;
   width:100%;
   top:0px;left:0px;
-  box-shadow: 0px 2px 18px 0px rgba(0,0,0,0.15);
+  box-shadow: 0px 2px 18px 0px rgba(0,0,0,0.1);
 }
 
 .collapse.navbar-collapse[aria-expanded="false"] {

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -52,7 +52,8 @@
 }
 
 .navbar-toggle[aria-expanded="true"]:after {
-  content:"🞫";
+  content:"X";
+  font-weight:bold;
   color:#888;
 }
 


### PR DESCRIPTION
* El menu baja a medida scrolleas
* Tiene una pequeña sombra
* Como en móviles el menú tapa el contenido contemplando que se puede apretar por error se cambian las barras del menu por una x, para saber que con ella se sale

1:
![1](https://user-images.githubusercontent.com/10437394/33801751-9fda9608-dd43-11e7-9298-e9f8390aaa7d.PNG)

2:
![2](https://user-images.githubusercontent.com/10437394/33801752-a1d0f290-dd43-11e7-99cd-4b1e149fd1ac.PNG)

3:
![3](https://user-images.githubusercontent.com/10437394/33801753-a55d96a2-dd43-11e7-9b3f-e84916a0d3bc.PNG)

4:
![4](https://user-images.githubusercontent.com/10437394/33801754-a6b3b48c-dd43-11e7-8b0a-1446b0c75f8c.PNG)