### PR TITLE
Arreglo de los anchors del indice del FAQ

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -14,9 +14,16 @@
           {{ content }}
         </div>
       </main>
-      
+
       <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
       <script src="{{ '/assets/js/bootstrap.min.js' | relative_url }}"></script>
+      <script>
+        $("#markdown-toc li a").click(function(e) {
+            e.preventDefault();
+            var aux = $(this).attr("href");
+            $('html,body').animate({scrollTop: $(aux).position().top-$("nav.navbar").height()},0);
+        });
+      </script>
 
       {% include footer.html %}
 


### PR DESCRIPTION

Por la barra posicionada de forma absoluta los anchors del indice hacen esto:

![antes](https://user-images.githubusercontent.com/10437394/37429222-78ff0a14-27ad-11e8-9a21-19de5dd54f97.gif)


No muestran el titulo porque se lo come el navbar, asique cambie el comportamiento del evento con JS (y funciona con todos los indices que se generen en el futuro con markdown ya que tienen el mismo ID)


Con el cambio:

![ahora](https://user-images.githubusercontent.com/10437394/37429331-b4c94f50-27ad-11e8-8f84-2f9d52915290.gif)
