### PR TITLE
Saco referencias a fechas de entrega en enunciados de TPs

### DIFF
--- a/static/tps/tda/03_pila.md
+++ b/static/tps/tda/03_pila.md
@@ -7,7 +7,7 @@ permalink: /tps/pila
 Pila
 =======
 
-Para el viernes 8 de septiembre tienen que entregar una implementación de pila dinámica (es decir que pueda crecer o reducirse según la cantidad de elementos) que contenga punteros genéricos (`void*`).
+El trabajo a realizar es el de una implementación de pila dinámica (es decir que pueda crecer o reducirse según la cantidad de elementos) que contenga punteros genéricos (`void*`).
 
 En el archivo [pila.zip](https://sites.google.com/site/fiuba7541rw/tps/pila/pila.zip?attredirects=0&d=1) encontrarán el archivo `pila.h` que tienen que utilizar.  En este archivo están definidas las primitivas que tendrán que implementar, con su correspondiente documentación. Todas las primitivas tienen que funcionar en _tiempo constante_.
 

--- a/static/tps/tda/04_cola.md
+++ b/static/tps/tda/04_cola.md
@@ -7,7 +7,7 @@ permalink: /tps/cola
 Cola enlazada
 =============
 
-Se incluye en [cola.zip](https://sites.google.com/site/fiuba7541rw/tps/cola/cola.zip?attredirects=0&d=1) el archivo `cola.h` correspondiente al ejercicio de la cola enlazada para el viernes 15 de septiembre.
+Se incluye en [cola.zip](https://sites.google.com/site/fiuba7541rw/tps/cola/cola.zip?attredirects=0&d=1) el archivo `cola.h` correspondiente al ejercicio de la cola enlazada.
 
 La entrega es muy similar a la realizada para el TDA Pila.  Excepto que la función para destruir la cola recibe por parámetro una función para destruir uno a uno los elementos, que puede ser `NULL` en el caso de que no haya que destruirlos.
 

--- a/static/tps/tda/05_lista.md
+++ b/static/tps/tda/05_lista.md
@@ -7,7 +7,7 @@ permalink: /tps/lista
 Lista enlazada
 ==============
 
-Estas son las primitivas de listas que tienen que implementar para el viernes 22 de septiembre. 
+Estas son las primitivas de listas que tienen que implementar.
 
 En esta entrega les agregamos el requerimiento de escribir la documentación completa de las primitivas, con sus correspondientes pre y post condiciones, para esto pueden usar de muestra los archivos .h que ya utilizaron para la implementación de pilas y colas.
 

--- a/static/tps/tda/06_hash.md
+++ b/static/tps/tda/06_hash.md
@@ -7,7 +7,7 @@ permalink: /tps/hash
 Tabla de Hash
 =============
 
-Para el **viernes 13 de octubre** deben entregar de **forma grupal** el tipo abstracto de datos Tabla de Hash, que se puede implementar mediante un hash abierto o cerrado, a elección.
+El trabajo que deben entregar de **forma grupal** es el tipo abstracto de datos Tabla de Hash, que se puede implementar mediante un hash abierto o cerrado, a elección.
 
 #### Primitivas del hash
 ``` cpp

--- a/static/tps/tda/07_abb.md
+++ b/static/tps/tda/07_abb.md
@@ -7,7 +7,7 @@ permalink: /tps/abb
 Árbol Binario de Búsqueda
 =============
 
-Para el **viernes 27 de octubre** deben implementar un Árbol Binario de Búsqueda (ABB), según las siguientes definiciones y primitivas:
+El trabajo que deben entregar de **forma grupal** es el tipo de dato abstracto Árbol Binario de Búsqueda (ABB), según las siguientes definiciones y primitivas:
 
 ``` cpp
 typedef struct abb abb_t;

--- a/static/tps/tda/08_heap.md
+++ b/static/tps/tda/08_heap.md
@@ -7,7 +7,7 @@ permalink: /tps/heap
 Heap
 =============
 
-Para el **lunes 6 de noviembre** deben implementar el tipo de dato abstracto Cola de Prioridad, utilizando un Heap.
+El trabajo que deben entregar de **forma grupal** es el tipo de dato abstracto Cola de Prioridad, utilizando un Heap.
 
 #### Primitivas del heap
 ``` cpp


### PR DESCRIPTION
Para evitar reescribir el enunciado de los TDA en cada publicación de entrega. Las fechas ya están publicadas en la tab de calendario, en la de TPs, y hasta podrían agregarse en el post de publicación de cada tp.