### PR TITLE
trabajos.yml: Archivo con toda la metadata de los trabajos

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,32 +27,30 @@ el nuevo contenido tras escribir un archivo.)
 
 ## Cómo realizar la publicación de un TP
 
-Para todo tipo de TPs (incluyendo TDAs), es necesario crear un archivo de post dentro del directorio `_posts`. El nombre del archivo debe ser `YYYY-MM-DD-nombre.md`, como convención para todos los posts. El formato que debe tener un post de TP debe ser: 
+Al principio del cuatrimestre actualizar el archivo `_data/trabajos.yml` para reflejar las nuevas fechas de publicación y entrega.
+
+Para todo tipo de TPs (incluyendo TDAs), es necesario crear un archivo de post dentro del directorio `_posts`. El nombre del archivo debe ser `YYYY-MM-DD-publicacion-trabajo.md`, como convención para todos los posts. El formato que debe tener un post de TP debe ser: 
 ```
 ---
 layout: post
-title: "Título entrega"
-date: YYYY-MM-DD 13:00:00 -0300 (fecha de publicacion)
+title: "Publicado TDA Cola"
+date: 2018-04-07 15:00:00 -0300
 
-es_TP: True
-nombre_TP: Nombre (e.g. Pila)
-fin_cuatrimestre: YYYY-MM-DD
-fecha_entrega: fecha
-zip: nombre.zip
-link_zip: Link del zip
-link_enunciado: /tps/nombre-entrega
+trabajo: 'Cola'
 ---
-
-Contenido (que aparece en la página principal, en `Novedades`)
+{% for tp in site.data.trabajos.trabajos %}
+{% if tp.id == page.trabajo %}{% assign TP = tp%}{% endif %}
+{% endfor %}
+Publicado: [{{TP.id}}]({{TP.enunciado_link | relative_url }}) para el {{TP.entrega}}.
 ```
 
-Para los TDAs, con solamente poner la información correspondiente, es suficiente (salvo alguna eventual actualización, o corrección del enunciado). Se puede encontrar el link al zip (y otros detalles) en posts de misma publicación de tp de cuatrimestres anteriores. 
+Solo deben modificarse las primeras 3 lineas. El resto es magia de Liquid. Por último, fijarse en `_data/trabajos.yml` que los datos esten al día.
 
-Para el caso de TPs, es necesario crear el enunciado agregando el directorio `static/tps/cuatrimestre/tpX` (`X` sea 1, 2 o 3), y que dentro de éste haya un archivo `index.md` con el enunciado correspondiente. Después, hacer también el post. En caso de no tener algo para descargar desde la página de tps, se pueden obviar los campos `zip` y `link_zip`. Cualquier archivo adicional que quiera subirse para el tp (e.g. imágenes) debe hacerse dentro del directorio `assets/tps`. 
+Para el caso de TPs, es necesario crear el enunciado agregando el directorio `static/tps/cuatrimestre/tpX` (`X` sea 1, 2 o 3), y que dentro de éste haya un archivo `index.md` con el enunciado correspondiente. Después, hacer también el post. Cualquier archivo adicional que quiera subirse para el tp (e.g. imágenes) debe hacerse dentro del directorio `assets/tps`. 
 
 Con agregar el post, se actualiza automáticamente: 
 - La sección de novedades, de la página principal (muestra las últimas 15 novedades).
-- La página de TPs, que automáticamente obtiene todos los posts relacionados a tps (campo `es_TP`) para listarlos. Por este listado es importante el campo `fin_cuatrimestre`, ya que no muestra TPs cuya fecha de fin de cuatrimestre haya sido superada. Por lo tanto, la fecha a poner será el primero de agosto del corriente año, para el primer cuatrimestre, y el primero de enero o febrero del año siguiente para el segundo cuatrimestre. 
+- La página de TPs, que automáticamente obtiene todos los posts relacionados a tps para listarlos. 
 
 Además, es necesario habilitar la entrega en el sistema de entregas (de esto se encargan algunas personas con permisos).
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ el nuevo contenido tras escribir un archivo.)
 
 Al principio del cuatrimestre actualizar el archivo `_data/trabajos.yml` para reflejar las nuevas fechas de publicación y entrega.
 
-Para todo tipo de TPs (incluyendo TDAs), es necesario crear un archivo de post dentro del directorio `_posts`. El nombre del archivo debe ser `YYYY-MM-DD-publicacion-trabajo.md`, como convención para todos los posts. El formato que debe tener un post de TP debe ser: 
+Para todo tipo de TPs (incluyendo TDAs), es necesario crear un archivo de post dentro del directorio `_posts`. El nombre del archivo debe ser `YYYY-MM-DD-publicacion-trabajo.md`, como convención para todos los posts. El formato que debe tener un post de TP debe ser, con el ejemplo de la publicación de cola: 
 ```
 ---
 layout: post

--- a/_data/cuatrimestre.yml
+++ b/_data/cuatrimestre.yml
@@ -1,0 +1,3 @@
+fin_cuatrimestre: 2018-08-01
+#Primeros cuatrimestres terminan el primero de agosto
+#Segundos Cuatrimestres terminan el primero de febrero

--- a/_data/trabajos.yml
+++ b/_data/trabajos.yml
@@ -1,0 +1,25 @@
+fin_cuatrimestre: 2018-08-01
+#Primeros cuatrimestres terminan el primero de agosto
+#Segundos Cuatrimestres terminan el primero de febrero
+
+trabajos:
+- id: TP0
+  publicacion: 2018-03-17
+  entrega: 23 de marzo
+  zip: tp0.zip
+  zip_link: https://drive.google.com/open?id=1yMiOLQiE2yrTBqoCirNAq5cG4-l3f0_n
+  enunciado_link: /tps/tp0
+
+- id: VD
+  publicacion: 2018-03-23
+  entrega: 26 de marzo
+  zip: vd.zip
+  zip_link: https://drive.google.com/open?id=1t6Uj8rUQUEZk7E5OpzxoKtlyFi5HGDxC
+  enunciado_link: /tps/vd
+
+- id: Pila
+  publicacion: 2018-03-27
+  entrega: 6 de abril
+  zip: pila.zip
+  zip_link: https://drive.google.com/open?id=1oPWpgKH4kePwSXDnkkAKeNRpabsV2SsI
+  enunciado_link: /tps/pila

--- a/_data/trabajos.yml
+++ b/_data/trabajos.yml
@@ -23,3 +23,59 @@ trabajos:
   zip: pila.zip
   zip_link: https://drive.google.com/open?id=1oPWpgKH4kePwSXDnkkAKeNRpabsV2SsI
   enunciado_link: /tps/pila
+
+- id: Cola
+  publicacion: 2018-04-06
+  entrega: 16 de abril
+  zip: cola.zip
+  zip_link: https://drive.google.com/open?id=14FBBgw5aO4BgyhSit93M3YVhUqYAZYlR
+  enunciado_link: /tps/cola
+
+- id: Lista
+  publicacion: 2018-04-16
+  entrega: 23 de abril
+  zip: lista.zip
+  zip_link: https://drive.google.com/open?id=171IO3RKSbpuI8EsK9YFWrmNNvg-stjF1
+  enunciado_link: /tps/lista
+
+- id: TP1
+  publicacion: 2018-04-23
+  entrega: 14 de mayo
+  zip:
+  zip_link:
+  enunciado_link: /tps/2018_01/tp1
+
+- id: Hash
+  publicacion: 2018-05-12
+  entrega: 11 de mayo
+  zip: hash.zip
+  zip_link: https://drive.google.com/open?id=1SiMNVEP6VhlDNl4YnBaewmgCJBNVHRhR
+  enunciado_link: /tps/hash
+
+- id: ABB
+  publicacion: 2018-05-11
+  entrega: 28 de mayo
+  zip: abb.zip
+  zip_link: https://drive.google.com/open?id=1p8V7p5dNo5FxLCJcysBXSmP0kdrPSnHy
+  enunciado_link: /tps/abb
+
+- id: Heap
+  publicacion: 2018-05-21
+  entrega: 6 de junio
+  zip: heap.zip
+  zip_link: https://drive.google.com/open?id=1zfNPouzWN4HCnKvSTbY5HH9N_E-qPG2n
+  enunciado_link: /tps/heap
+
+- id: TP2
+  publicacion: 2018-05-21
+  entrega: 15 de junio
+  zip:
+  zip_link:
+  enunciado_link: /tps/2018_01/tp2
+
+- id: TP3
+  publicacion: 2018-06-11
+  entrega: 29 de junio
+  zip:
+  zip_link:
+  enunciado_link: /tps/2018_01/tp3

--- a/_data/trabajos.yml
+++ b/_data/trabajos.yml
@@ -1,8 +1,3 @@
-fin_cuatrimestre: 2018-08-01
-#Primeros cuatrimestres terminan el primero de agosto
-#Segundos Cuatrimestres terminan el primero de febrero
-
-trabajos:
 - id: TP0
   publicacion: 2018-03-17
   entrega: 23 de marzo

--- a/_posts/2018-03-17-publicacion-tp0.md
+++ b/_posts/2018-03-17-publicacion-tp0.md
@@ -3,13 +3,10 @@ layout: post
 title: "TP0 publicado"
 date: 2018-03-17 17:32:00 -0300
 
-es_TP: True
-nombre_TP: TP0
-fecha_entrega: 23 de marzo
-fin_cuatrimestre: 2018-08-01
-zip: tp0.zip
-link_zip: https://drive.google.com/open?id=1yMiOLQiE2yrTBqoCirNAq5cG4-l3f0_n
-link_enunciado: /tps/tp0
+trabajo: 'TP0'
 ---
 
-Publicado el [TP0]({{ 'tps/tp0' | relative_url }}) con fecha de entrega para el 23 de marzo.
+{% for tp in site.data.trabajos.trabajos %}
+{% if tp.id == page.trabajo %}{% assign TP = tp%}{% endif %}
+{% endfor %}
+Publicado: [{{TP.id}}]({{TP.enunciado_link | relative_url }}) para el {{TP.entrega}}.

--- a/_posts/2018-03-17-publicacion-tp0.md
+++ b/_posts/2018-03-17-publicacion-tp0.md
@@ -6,7 +6,7 @@ date: 2018-03-17 17:32:00 -0300
 trabajo: 'TP0'
 ---
 
-{% for tp in site.data.trabajos.trabajos %}
+{% for tp in site.data.trabajos %}
 {% if tp.id == page.trabajo %}{% assign TP = tp%}{% endif %}
 {% endfor %}
 Publicado: [{{TP.id}}]({{TP.enunciado_link | relative_url }}) para el {{TP.entrega}}.

--- a/_posts/2018-03-23-publicacion-vd.md
+++ b/_posts/2018-03-23-publicacion-vd.md
@@ -3,13 +3,10 @@ layout: post
 title: "Vector dinámico publicado"
 date: 2018-03-23 18:00:00 -0300
 
-es_TP: True
-nombre_TP: VD
-fecha_entrega: 26 de marzo
-fin_cuatrimestre: 2018-08-01
-zip: vd.zip
-link_zip: https://drive.google.com/open?id=1t6Uj8rUQUEZk7E5OpzxoKtlyFi5HGDxC
-link_enunciado: /tps/vd
+trabajo: 'VD'
 ---
 
-Publicado el [vector dinámico]({{ 'tps/vd' | relative_url }}) con fecha de entrega para el 26 de marzo.
+{% for tp in site.data.trabajos.trabajos %}
+{% if tp.id == page.trabajo %}{% assign TP = tp%}{% endif %}
+{% endfor %}
+Publicado: [{{TP.id}}]({{TP.enunciado_link | relative_url }}) para el {{TP.entrega}}.

--- a/_posts/2018-03-23-publicacion-vd.md
+++ b/_posts/2018-03-23-publicacion-vd.md
@@ -6,7 +6,7 @@ date: 2018-03-23 18:00:00 -0300
 trabajo: 'VD'
 ---
 
-{% for tp in site.data.trabajos.trabajos %}
+{% for tp in site.data.trabajos %}
 {% if tp.id == page.trabajo %}{% assign TP = tp%}{% endif %}
 {% endfor %}
 Publicado: [{{TP.id}}]({{TP.enunciado_link | relative_url }}) para el {{TP.entrega}}.

--- a/_posts/2018-03-27-publicacion-pila.md
+++ b/_posts/2018-03-27-publicacion-pila.md
@@ -6,7 +6,7 @@ date: 2018-03-27 13:00:00 -0300
 trabajo: 'Pila'
 ---
 
-{% for tp in site.data.trabajos.trabajos %}
+{% for tp in site.data.trabajos %}
 {% if tp.id == page.trabajo %}{% assign TP = tp%}{% endif %}
 {% endfor %}
 Publicado: [{{TP.id}}]({{TP.enunciado_link | relative_url }}) para el {{TP.entrega}}.

--- a/_posts/2018-03-27-publicacion-pila.md
+++ b/_posts/2018-03-27-publicacion-pila.md
@@ -3,14 +3,11 @@ layout: post
 title: "Pila publicado"
 date: 2018-03-27 13:00:00 -0300
 
-es_TP: True
-nombre_TP: Pila
-fin_cuatrimestre: 2018-08-01
-fecha_entrega: 6 de abril
-zip: pila.zip
-link_zip: https://drive.google.com/open?id=1oPWpgKH4kePwSXDnkkAKeNRpabsV2SsI
-link_enunciado: /tps/pila
+trabajo: 'Pila'
 ---
 
-Publicado la [Pila]({{ 'tps/pila' | relative_url }}) con fecha de entrega para el 6 de abril.
+{% for tp in site.data.trabajos.trabajos %}
+{% if tp.id == page.trabajo %}{% assign TP = tp%}{% endif %}
+{% endfor %}
+Publicado: [{{TP.id}}]({{TP.enunciado_link | relative_url }}) para el {{TP.entrega}}.
 

--- a/_posts/2018-04-07-publicacion-cola.md
+++ b/_posts/2018-04-07-publicacion-cola.md
@@ -6,7 +6,7 @@ date: 2018-04-07 15:00:00 -0300
 trabajo: 'Cola'
 ---
 
-{% for tp in site.data.trabajos.trabajos %}
+{% for tp in site.data.trabajos %}
 {% if tp.id == page.trabajo %}{% assign TP = tp%}{% endif %}
 {% endfor %}
 Publicado: [{{TP.id}}]({{TP.enunciado_link | relative_url }}) para el {{TP.entrega}}.

--- a/_posts/2018-04-07-publicacion-cola.md
+++ b/_posts/2018-04-07-publicacion-cola.md
@@ -3,13 +3,10 @@ layout: post
 title: "Publicado TDA Cola"
 date: 2018-04-07 15:00:00 -0300
 
-es_TP: True
-nombre_TP: Cola
-fecha_entrega: 16 de abril
-fin_cuatrimestre: 2018-08-01
-zip: cola.zip
-link_zip: https://drive.google.com/open?id=14FBBgw5aO4BgyhSit93M3YVhUqYAZYlR
-link_enunciado: /tps/cola
+trabajo: 'Cola'
 ---
 
-Publicado TDA [Cola]({{ 'tps/cola' | relative_url }}).
+{% for tp in site.data.trabajos.trabajos %}
+{% if tp.id == page.trabajo %}{% assign TP = tp%}{% endif %}
+{% endfor %}
+Publicado: [{{TP.id}}]({{TP.enunciado_link | relative_url }}) para el {{TP.entrega}}.

--- a/static/04_tps.md
+++ b/static/04_tps.md
@@ -4,6 +4,7 @@ title: TPs
 permalink: /tps/
 ---
 {% assign hoy = site.time | date: "%Y-%m-%d" %}
+{% assign expiracion = site.data.trabajos.fin_cuatrimestre | date: "%Y-%m-%d" %}
 
 TPs
 =======
@@ -12,5 +13,5 @@ A continuación encontrarán las entregas que iremos planteando a lo largo de la
 materia.
 
 {: .table .table-striped}
-| **TP**       | **Código**      | **Fecha de entrega** |{% for tp in site.posts reversed %}{% assign expiracion = tp.fin_cuatrimestre | date: "%Y-%m-%d" %}{% if tp.es_TP and hoy < expiracion %}
-|[{{tp.nombre_TP}}]({{tp.link_enunciado | relative_url}}) | [{{tp.zip}}]({{tp.link_zip}}) | {{tp.fecha_entrega}}{% endif %}{% endfor %}
+| **TP**       | **Código**      | **Fecha de entrega** |{% for tp in site.data.trabajos.trabajos %}{% assign comienzo = tp.publicacion | date: "%Y-%m-%d" %}{% if hoy > comienzo and hoy < expiracion %}
+|[{{tp.id}}]({{tp.enunciado_link | relative_url}}) | [{{tp.zip}}]({{tp.zip_link}}) | {{tp.entrega}}{% endif %}{% endfor %}

--- a/static/04_tps.md
+++ b/static/04_tps.md
@@ -4,7 +4,7 @@ title: TPs
 permalink: /tps/
 ---
 {% assign hoy = site.time | date: "%Y-%m-%d" %}
-{% assign expiracion = site.data.trabajos.fin_cuatrimestre | date: "%Y-%m-%d" %}
+{% assign expiracion = site.data.cuatrimestre.fin_cuatrimestre | date: "%Y-%m-%d" %}
 
 TPs
 =======
@@ -13,5 +13,5 @@ A continuación encontrarán las entregas que iremos planteando a lo largo de la
 materia.
 
 {: .table .table-striped}
-| **TP**       | **Código**      | **Fecha de entrega** |{% for tp in site.data.trabajos.trabajos %}{% assign comienzo = tp.publicacion | date: "%Y-%m-%d" %}{% if hoy > comienzo and hoy < expiracion %}
+| **TP**       | **Código**      | **Fecha de entrega** |{% for tp in site.data.trabajos %}{% assign comienzo = tp.publicacion | date: "%Y-%m-%d" %}{% if hoy > comienzo and hoy < expiracion %}
 |[{{tp.id}}]({{tp.enunciado_link | relative_url}}) | [{{tp.zip}}]({{tp.zip_link}}) | {{tp.entrega}}{% endif %}{% endfor %}


### PR DESCRIPTION
Dejo una forma para que sea más cómoda la actualizacion de todos los cuatrimestres de tps. En vez de que la metadata del tp quede copypasteada en la publicación, ahora se saca de el nuevo archivo (_data/trabajos.yml). En lo visible, el sitio esta igual.

(Actualizado el readme para mas detalles)