### PR TITLE
Asociar los enunciados de los TPs con su metadata respectiva

### DIFF
--- a/static/tps/tda/01_tp0.md
+++ b/static/tps/tda/01_tp0.md
@@ -2,12 +2,17 @@
 layout: page
 title: TP0
 permalink: /tps/tp0
+
+trabajo: 'TP0'
 ---
+{% for tp in site.data.trabajos %}
+{% if tp.id == page.trabajo %}{% assign TP = tp%}{% endif %}
+{% endfor %}
 
 TP0
 =======
 
-El adjunto [tp0.zip](https://drive.google.com/open?id=1yMiOLQiE2yrTBqoCirNAq5cG4-l3f0_n) contiene varios archivos.
+El adjunto [{{TP.zip}}]({{TP.zip_link}}) contiene varios archivos.
 Deben editar el archivo `tp0.c`, completando las cuatro funciones que 
 aparecen en el código fuente: `swap()`,  `maximo()`, `comparar()` y `seleccion()`.
 (Los comentarios en el archivo indican qué debe hacer cada función).

--- a/static/tps/tda/02_vd.md
+++ b/static/tps/tda/02_vd.md
@@ -2,12 +2,17 @@
 layout: page
 title: Vector dinámico
 permalink: /tps/vd
+
+trabajo: 'VD'
 ---
+{% for tp in site.data.trabajos %}
+{% if tp.id == page.trabajo %}{% assign TP = tp%}{% endif %}
+{% endfor %}
 
 Vector dinámico
 =======
 
-El archivo [vd.zip](https://drive.google.com/open?id=1t6Uj8rUQUEZk7E5OpzxoKtlyFi5HGDxC)
+El archivo [{{TP.zip}}]({{TP.zip_link}})
 adjunto contiene una definición del tipo de dato _vector dinámico_ que deberán completar.
 
 En particular, deberán leer el archivo `vector_dinamico.h` con la documentación, e implementar en

--- a/static/tps/tda/03_pila.md
+++ b/static/tps/tda/03_pila.md
@@ -2,14 +2,19 @@
 layout: page
 title: Pila
 permalink: /tps/pila
+
+trabajo: 'Pila'
 ---
+{% for tp in site.data.trabajos %}
+{% if tp.id == page.trabajo %}{% assign TP = tp%}{% endif %}
+{% endfor %}
 
 Pila
 =======
 
 El trabajo a realizar es el de una implementación de pila dinámica (es decir que pueda crecer o reducirse según la cantidad de elementos) que contenga punteros genéricos (`void*`).
 
-En el archivo [pila.zip](https://drive.google.com/open?id=1oPWpgKH4kePwSXDnkkAKeNRpabsV2SsI) encontrarán el archivo `pila.h` que tienen que utilizar.  En este archivo están definidas las primitivas que tendrán que implementar, con su correspondiente documentación. Todas las primitivas tienen que funcionar en _tiempo constante_.
+En el archivo [{{TP.zip}}]({{TP.zip_link}}) encontrarán el archivo `pila.h` que tienen que utilizar.  En este archivo están definidas las primitivas que tendrán que implementar, con su correspondiente documentación. Todas las primitivas tienen que funcionar en _tiempo constante_.
 
 Hay que escribir el archivo `pila.c`, con la implementación de la estructura de la pila y de cada una de las primitivas incluidas en el encabezado.  Además de las primitivas, pueden tener funciones auxiliares, de uso interno, que no hace falta que estén declaradas dentro de pila.h. En pila.h se encuentran únicamente las primitivas que el usuario de la pila tiene que conocer.
 

--- a/static/tps/tda/04_cola.md
+++ b/static/tps/tda/04_cola.md
@@ -2,12 +2,17 @@
 layout: page
 title: Cola
 permalink: /tps/cola
+
+trabajo: 'Cola'
 ---
+{% for tp in site.data.trabajos %}
+{% if tp.id == page.trabajo %}{% assign TP = tp%}{% endif %}
+{% endfor %}
 
 Cola enlazada
 =============
 
-Se incluye en [cola.zip](https://drive.google.com/open?id=14FBBgw5aO4BgyhSit93M3YVhUqYAZYlR) el archivo `cola.h` correspondiente al ejercicio de la cola enlazada.
+Se incluye en [{{TP.zip}}]({{TP.zip_link}}) el archivo `cola.h` correspondiente al ejercicio de la cola enlazada.
 
 La entrega es muy similar a la realizada para el TDA Pila.  Excepto que la función para destruir la cola recibe por parámetro una función para destruir uno a uno los elementos, que puede ser `NULL` en el caso de que no haya que destruirlos.
 

--- a/static/tps/tda/05_lista.md
+++ b/static/tps/tda/05_lista.md
@@ -2,10 +2,17 @@
 layout: page
 title: Lista
 permalink: /tps/lista
+
+trabajo: 'Lista'
 ---
+{% for tp in site.data.trabajos %}
+{% if tp.id == page.trabajo %}{% assign TP = tp%}{% endif %}
+{% endfor %}
 
 Lista enlazada
 ==============
+
+Se incluye en [{{TP.zip}}]({{TP.zip_link}}) un ejemplo de uso de iteradores externos.
 
 Estas son las primitivas de listas que tienen que implementar.
 

--- a/static/tps/tda/06_hash.md
+++ b/static/tps/tda/06_hash.md
@@ -2,7 +2,12 @@
 layout: page
 title: Hash
 permalink: /tps/hash
+
+trabajo: 'Hash'
 ---
+{% for tp in site.data.trabajos %}
+{% if tp.id == page.trabajo %}{% assign TP = tp%}{% endif %}
+{% endfor %}
 
 Tabla de Hash
 =============
@@ -35,7 +40,7 @@ void hash_iter_destruir(hash_iter_t* iter);
 
 El iterador debe permitir recorrer todos los elementos almacenados en el hash, sin importar el orden en el que son devueltos.
 
-Se adjunta, además, un [archivo de pruebas](https://drive.google.com/open?id=1SiMNVEP6VhlDNl4YnBaewmgCJBNVHRhR) que pueden utilizar para verificar que la estructura funciona correctamente.  El corrector automático, igualmente, añade más pruebas.
+Se adjunta, además, un [archivo de pruebas]({{TP.zip_link}}) que pueden utilizar para verificar que la estructura funciona correctamente.  El corrector automático, igualmente, añade más pruebas. Para esta entrega no deben entregarse pruebas propias.
 
 Al igual que para las entregas anteriores, deberán entregar el código en papel, con el nombre y padrón de los integrantes del grupo, imprimiendo los archivos `hash.h` y `hash.c`.   
 

--- a/static/tps/tda/07_abb.md
+++ b/static/tps/tda/07_abb.md
@@ -2,7 +2,12 @@
 layout: page
 title: Árbol Binario de Búsqueda
 permalink: /tps/abb
+
+trabajo: 'ABB'
 ---
+{% for tp in site.data.trabajos %}
+{% if tp.id == page.trabajo %}{% assign TP = tp%}{% endif %}
+{% endfor %}
 
 Árbol Binario de Búsqueda
 =============
@@ -57,6 +62,8 @@ bool abb_iter_in_al_final(const abb_iter_t *iter);
 void abb_iter_in_destruir(abb_iter_t* iter);
 ```
 Contamos con un [script de pruebas](https://github.com/algoritmos-rw/algo2_abb_test) que pueden ejecutar para verificar que la estructura que implementaron funciona correctamente. De todas formas, al igual que en entregas anteriores, deben realizar sus propias pruebas (pueden tomar las pruebas del hash como referencia, ya que el comportamiento de ambas estructuras es muy similar).
+
+Se incluye en [{{TP.zip}}]({{TP.zip_link}}) el archivo de main correspondiente al ejercicio.
 
 Como siempre, deben subir el código completo a la [página de entregas de la materia]({{site.entregas}}) y también entregarlo impreso con nombre y padrón de ambos integrantes, si su corrector así lo requiere.
 

--- a/static/tps/tda/08_heap.md
+++ b/static/tps/tda/08_heap.md
@@ -2,7 +2,14 @@
 layout: page
 title: Heap
 permalink: /tps/heap
+
+trabajo: 'Heap'
 ---
+{% for tp in site.data.trabajos %}
+{% if tp.id == page.trabajo %}{% assign TP = tp%}{% endif %}
+{% endfor %}
+
+Se incluye en [{{TP.zip}}]({{TP.zip_link}}) el archivo `heap.h` correspondiente al ejercicio de la cola de prioridad.
 
 Heap
 =============


### PR DESCRIPTION
Para evitar que si cambia el link de un zip en un lado haya que acordarse de cambiarlo en otro, por ejemplo.