### PR TITLE
Publicaciones de TPs segun fecha, para ahorrar el hacer un post por publicación

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,20 +6,24 @@ Este es el repositorio del sitio web de Algoritmos y Programación II, publicado
 
 Cualquier commit en el directorio raíz se auto-publica en la página al hacer push a la rama _master_. GitHub se encarga de ese proceso.
 
-Para visualizar los cambios de manera local, se debe instalar Jekyll. El archivo [Gemfile](Gemfile) lo hace bastante fácil:
+Para visualizar los cambios de manera local, se debe instalar [Jekyll](https://jekyllrb.com/docs/installation/#ubuntu). El archivo [Gemfile](Gemfile) lo hace bastante fácil:
 
 ```
 # Setup inicial
 
-$ apt-get install bundler
+$ apt-get install ruby ruby-dev bundler
+$ gem install jekyll bundler
 $ git clone git@github.com:algoritmos-rw/algo2
 $ cd algo2
 $ bundle install --path=../gems
+$ // de tener problemas con nokogiri: apt-get install libxml2-dev
 
 # Para visualizar al editar
 
 $ cd algo2
 $ bundle exec jekyll serve --livereload
+$ // de tener problemas con javascript runtime: apt-get install nodejs
+
 ```
 
 (La opción `--livereload` es opcional, pero fuerza al navegador a mostrar
@@ -27,28 +31,9 @@ el nuevo contenido tras escribir un archivo.)
 
 ## Cómo realizar la publicación de un TP
 
-Al principio del cuatrimestre actualizar el archivo `_data/trabajos.yml` para reflejar las nuevas fechas de publicación y entrega.
-
-Para todo tipo de TPs (incluyendo TDAs), es necesario crear un archivo de post dentro del directorio `_posts`. El nombre del archivo debe ser `YYYY-MM-DD-publicacion-trabajo.md`, como convención para todos los posts. El formato que debe tener un post de TP debe ser, con el ejemplo de la publicación de cola: 
-```
----
-layout: post
-title: "Publicado TDA Cola"
-date: 2018-04-07 15:00:00 -0300
-
-trabajo: Cola
----
-{% assign TP = site.data.trabajos[page.trabajo] %}
-Publicado: [{{TP.id}}]({{TP.enunciado_link | relative_url }}) para el {{TP.entrega}}.
-```
-
-Solo deben modificarse las primeras 3 lineas. El resto es magia de Liquid. Por último, fijarse en `_data/trabajos.yml` que los datos esten al día.
+Al principio del cuatrimestre actualizar el archivo `_data/trabajos.yml` y `_data/cuatrimestre.yml` para reflejar las nuevas fechas de publicación y entrega y de fin de cuatrimestre.
 
 Para el caso de TPs, es necesario crear el enunciado agregando el directorio `static/tps/cuatrimestre/tpX` (`X` sea 1, 2 o 3), y que dentro de éste haya un archivo `index.md` con el enunciado correspondiente. Después, hacer también el post. Cualquier archivo adicional que quiera subirse para el tp (e.g. imágenes) debe hacerse dentro del directorio `assets/tps`. 
-
-Con agregar el post, se actualiza automáticamente: 
-- La sección de novedades, de la página principal (muestra las últimas 15 novedades).
-- La página de TPs, que automáticamente obtiene todos los posts relacionados a tps para listarlos. 
 
 Además, es necesario habilitar la entrega en el sistema de entregas (de esto se encargan algunas personas con permisos).
 
@@ -59,4 +44,3 @@ Una vez que está por comenzar el cuatrimestre, es necesario actualizar la pági
 ## Subir nuevas encuestas
 
 Para subir las encuestas de un cuatrimestre, subir el archivo dentro del directorio `assets/encuestas`, con nombre `YYYY-cuat.html`. Actualizar también la página de encuestas (`static/08_encuestas.md`).
-

--- a/_data/trabajos.yml
+++ b/_data/trabajos.yml
@@ -1,7 +1,7 @@
 TP0:
   id: TP0
   publicacion: 2018-03-17
-  entrega: 23 de marzo
+  entrega: 2018-03-23
   zip: tp0.zip
   zip_link: https://drive.google.com/open?id=1yMiOLQiE2yrTBqoCirNAq5cG4-l3f0_n
   enunciado_link: /tps/tp0
@@ -9,7 +9,7 @@ TP0:
 VD:
   id: VD
   publicacion: 2018-03-23
-  entrega: 26 de marzo
+  entrega: 2018-03-26
   zip: vd.zip
   zip_link: https://drive.google.com/open?id=1t6Uj8rUQUEZk7E5OpzxoKtlyFi5HGDxC
   enunciado_link: /tps/vd
@@ -17,7 +17,7 @@ VD:
 Pila:
   id: Pila
   publicacion: 2018-03-27
-  entrega: 6 de abril
+  entrega: 2018-04-06
   zip: pila.zip
   zip_link: https://drive.google.com/open?id=1oPWpgKH4kePwSXDnkkAKeNRpabsV2SsI
   enunciado_link: /tps/pila
@@ -25,7 +25,7 @@ Pila:
 Cola:
   id: Cola
   publicacion: 2018-04-06
-  entrega: 16 de abril
+  entrega: 2018-04-16
   zip: cola.zip
   zip_link: https://drive.google.com/open?id=14FBBgw5aO4BgyhSit93M3YVhUqYAZYlR
   enunciado_link: /tps/cola
@@ -33,7 +33,7 @@ Cola:
 Lista:
   id: Lista
   publicacion: 2018-04-16
-  entrega: 23 de abril
+  entrega: 2018-04-23
   zip: lista.zip
   zip_link: https://drive.google.com/open?id=171IO3RKSbpuI8EsK9YFWrmNNvg-stjF1
   enunciado_link: /tps/lista
@@ -41,7 +41,7 @@ Lista:
 TP1:
   id: TP1
   publicacion: 2018-04-22
-  entrega: 14 de mayo
+  entrega: 2018-05-14
   zip: strutil.h
   zip_link: https://drive.google.com/file/d/1tTT0YJbjpJeMqwlk8keAvJUXlBH6Y8xx/view
   enunciado_link: /tps/2018_1/tp1
@@ -49,7 +49,7 @@ TP1:
 Hash:
   id: Hash
   publicacion: 2018-04-27
-  entrega: 14 de mayo
+  entrega: 2018-05-14
   zip: hash.zip
   zip_link: https://drive.google.com/open?id=1SiMNVEP6VhlDNl4YnBaewmgCJBNVHRhR
   enunciado_link: /tps/hash
@@ -57,7 +57,7 @@ Hash:
 ABB:
   id: ABB
   publicacion: 2018-05-11
-  entrega: 28 de mayo
+  entrega: 2018-05-28
   zip: abb.zip
   zip_link: https://drive.google.com/open?id=1p8V7p5dNo5FxLCJcysBXSmP0kdrPSnHy
   enunciado_link: /tps/abb
@@ -65,7 +65,7 @@ ABB:
 Heap:
   id: Heap
   publicacion: 2018-05-21
-  entrega: 6 de junio
+  entrega: 2018-06-06
   zip: heap.zip
   zip_link: https://drive.google.com/open?id=1zfNPouzWN4HCnKvSTbY5HH9N_E-qPG2n
   enunciado_link: /tps/heap
@@ -73,7 +73,7 @@ Heap:
 TP2:
   id: TP2
   publicacion: 2018-05-21
-  entrega: 15 de junio
+  entrega:  2018-06-15
   zip:
   zip_link:
   enunciado_link: /tps/2018_1/tp2
@@ -81,7 +81,7 @@ TP2:
 TP3:
   id: TP3
   publicacion: 2018-06-11
-  entrega: 29 de junio
+  entrega:  2018-06-29
   zip:
   zip_link:
   enunciado_link: /tps/2018_1/tp3

--- a/_data/trabajos.yml
+++ b/_data/trabajos.yml
@@ -73,7 +73,7 @@ Heap:
 TP2:
   id: TP2
   publicacion: 2018-05-21
-  entrega:  2018-06-15
+  entrega: 2018-06-15
   zip:
   zip_link:
   enunciado_link: /tps/2018_1/tp2
@@ -81,7 +81,7 @@ TP2:
 TP3:
   id: TP3
   publicacion: 2018-06-11
-  entrega:  2018-06-29
+  entrega: 2018-06-29
   zip:
   zip_link:
   enunciado_link: /tps/2018_1/tp3

--- a/assets/js/publicacionTPs.js
+++ b/assets/js/publicacionTPs.js
@@ -13,24 +13,32 @@ window.onload = agregarTPsATabla;
 function agregarTPsATabla() {
     var dtHoy = new Date();
     var hoy = (dtHoy.getYear() + "/" + dtHoy.getMonth() + 1) + "/" + (dtHoy.getDate()+1);
+    
+    var dtFinCuatrimestre = new Date("{{site.data.cuatrimestre.fin_cuatrimestre}}");
+    var finCuatrimestre = (dtFinCuatrimestre.getYear() + "/" + dtFinCuatrimestre.getMonth() + 1) + "/" + (dtFinCuatrimestre.getDate()+1);
+    
     {% for x in site.data.trabajos %}{% assign tp = x[1] %}
         var dtPublicacion = new Date("{{tp.publicacion}}");
         var dtEntrega = new Date("{{tp.entrega}}");
-        var publicacion = (dtPublicacion.getYear() + "/" + dtPublicacion.getMonth() + 1) + "/" + (dtPublicacion.getDate()+1);
+        var publicacion = dtPublicacion.getYear() + "/" + (dtPublicacion.getMonth() + 1) + "/" + (dtPublicacion.getDate()+1);
         
         var tabla = document.getElementById("tabla-trabajos");
         var fila = document.createElement("tr")
         
         if (hoy >= publicacion) fila.innerHTML += "<td> <a href={{tp.enunciado_link}}'>{{tp.id}}</a> </td>"
-        else fila.innerHTML += "<td> {{tp.id}} </td>"
+        else fila.innerHTML += "<td>" +finCuatrimestre +"</td>"
         
         if (hoy >= publicacion) fila.innerHTML += "<td> <a href='{{tp.zip_link}}'>{{tp.zip}}</a> </td>"
         else fila.innerHTML += "<td> {{tp.zip}} </td>"
         var prettyPublicacion = dtPublicacion.getDate() + ' de ' + monthNames[dtPublicacion.getMonth()];
         var prettyEntrega = dtEntrega.getDate() + ' de ' + monthNames[dtEntrega.getMonth()];
 
-        fila.innerHTML += "<td>" + prettyPublicacion + "</td>" 
-        fila.innerHTML += "<td>" + prettyEntrega + "</td>" 
+        if (hoy <= finCuatrimestre) fila.innerHTML += "<td>" + prettyPublicacion + "</td>"
+        else fila.innerHTML += "<td> </td>"
+
+        if (hoy <= finCuatrimestre) fila.innerHTML += "<td>" + prettyEntrega + "</td>"
+        else fila.innerHTML += "<td> </td>"
+
         tabla.appendChild(fila)
     {% endfor %}
 

--- a/assets/js/publicacionTPs.js
+++ b/assets/js/publicacionTPs.js
@@ -30,8 +30,8 @@ function agregarTPsATabla() {
         
         if (hoy >= publicacion && hoy <= finCuatrimestre) fila.innerHTML += "<td> <a href='{{tp.zip_link}}'>{{tp.zip}}</a> </td>"
         else fila.innerHTML += "<td> {{tp.zip}} </td>"
-        var prettyPublicacion = dtPublicacion.getDate() + ' de ' + monthNames[dtPublicacion.getMonth()];
-        var prettyEntrega = dtEntrega.getDate() + ' de ' + monthNames[dtEntrega.getMonth()];
+        var prettyPublicacion = dtPublicacion.getDate()+1 + ' de ' + monthNames[dtPublicacion.getMonth()];
+        var prettyEntrega = dtEntrega.getDate()+1 + ' de ' + monthNames[dtEntrega.getMonth()];
 
         if (hoy <= finCuatrimestre) fila.innerHTML += "<td>" + prettyPublicacion + "</td>"
         else fila.innerHTML += "<td> </td>"

--- a/assets/js/publicacionTPs.js
+++ b/assets/js/publicacionTPs.js
@@ -1,0 +1,28 @@
+---
+---
+
+window.onload = agregarTPsATabla;
+function agregarTPsATabla() {
+    var dtHoy = new Date();
+    var hoy = (dtHoy.getYear() + "/" + dtHoy.getMonth() + 1) + "/" + (dtHoy.getDate());
+    {% for x in site.data.trabajos %}{% assign tp = x[1] %}
+        var dtPublicacion = new Date("{{tp.publicacion}}");
+        var publicacion = (dtPublicacion.getYear() + "/" + dtPublicacion.getMonth() + 1) + "/" + (dtPublicacion.getDate()+1);
+        
+        var tabla = document.getElementById("tabla-trabajos");
+        var fila = document.createElement("tr")
+        
+        if (hoy >= publicacion) fila.innerHTML += "<td> <a href={{tp.enunciado_link}}'>{{tp.id}}</a> </td>"
+        else fila.innerHTML += "<td> {{tp.id}} </td>"
+        
+        if (hoy >= publicacion) fila.innerHTML += "<td> <a href='{{tp.zip_link}}'>{{tp.zip}}</a> </td>"
+        else fila.innerHTML += "<td> {{tp.zip}} </td>"
+        
+        fila.innerHTML += "<td> {{tp.publicacion}} </td>" 
+        fila.innerHTML += "<td> {{tp.entrega}} </td>" 
+        tabla.appendChild(fila)
+    {% endfor %}
+
+}
+
+

--- a/assets/js/publicacionTPs.js
+++ b/assets/js/publicacionTPs.js
@@ -25,10 +25,10 @@ function agregarTPsATabla() {
         var tabla = document.getElementById("tabla-trabajos");
         var fila = document.createElement("tr")
         
-        if (hoy >= publicacion) fila.innerHTML += "<td> <a href={{tp.enunciado_link}}'>{{tp.id}}</a> </td>"
-        else fila.innerHTML += "<td>" +finCuatrimestre +"</td>"
+        if (hoy >= publicacion && hoy <= finCuatrimestre) fila.innerHTML += "<td> <a href={{tp.enunciado_link}}'>{{tp.id}}</a> </td>"
+        else fila.innerHTML += "<td> {{tp.id}} </td>"
         
-        if (hoy >= publicacion) fila.innerHTML += "<td> <a href='{{tp.zip_link}}'>{{tp.zip}}</a> </td>"
+        if (hoy >= publicacion && hoy <= finCuatrimestre) fila.innerHTML += "<td> <a href='{{tp.zip_link}}'>{{tp.zip}}</a> </td>"
         else fila.innerHTML += "<td> {{tp.zip}} </td>"
         var prettyPublicacion = dtPublicacion.getDate() + ' de ' + monthNames[dtPublicacion.getMonth()];
         var prettyEntrega = dtEntrega.getDate() + ' de ' + monthNames[dtEntrega.getMonth()];

--- a/assets/js/publicacionTPs.js
+++ b/assets/js/publicacionTPs.js
@@ -1,12 +1,21 @@
 ---
 ---
 
+var monthNames = [
+    "Enero", "Febrero", "Marzo",
+    "Abril", "Mayo", "Junio", "Julio",
+    "Agosto", "Septiembre", "Octubre",
+    "Noviembre", "Diciembre"
+  ];
+
+
 window.onload = agregarTPsATabla;
 function agregarTPsATabla() {
     var dtHoy = new Date();
-    var hoy = (dtHoy.getYear() + "/" + dtHoy.getMonth() + 1) + "/" + (dtHoy.getDate());
+    var hoy = (dtHoy.getYear() + "/" + dtHoy.getMonth() + 1) + "/" + (dtHoy.getDate()+1);
     {% for x in site.data.trabajos %}{% assign tp = x[1] %}
         var dtPublicacion = new Date("{{tp.publicacion}}");
+        var dtEntrega = new Date("{{tp.entrega}}");
         var publicacion = (dtPublicacion.getYear() + "/" + dtPublicacion.getMonth() + 1) + "/" + (dtPublicacion.getDate()+1);
         
         var tabla = document.getElementById("tabla-trabajos");
@@ -17,9 +26,11 @@ function agregarTPsATabla() {
         
         if (hoy >= publicacion) fila.innerHTML += "<td> <a href='{{tp.zip_link}}'>{{tp.zip}}</a> </td>"
         else fila.innerHTML += "<td> {{tp.zip}} </td>"
-        
-        fila.innerHTML += "<td> {{tp.publicacion}} </td>" 
-        fila.innerHTML += "<td> {{tp.entrega}} </td>" 
+        var prettyPublicacion = dtPublicacion.getDate() + ' de ' + monthNames[dtPublicacion.getMonth()];
+        var prettyEntrega = dtEntrega.getDate() + ' de ' + monthNames[dtEntrega.getMonth()];
+
+        fila.innerHTML += "<td>" + prettyPublicacion + "</td>" 
+        fila.innerHTML += "<td>" + prettyEntrega + "</td>" 
         tabla.appendChild(fila)
     {% endfor %}
 

--- a/static/04_tps.md
+++ b/static/04_tps.md
@@ -3,8 +3,6 @@ layout: page
 title: TPs
 permalink: /tps/
 ---
-{% assign hoy = site.time | date: "%Y-%m-%d" %}
-{% assign expiracion = site.data.cuatrimestre.fin_cuatrimestre | date: "%Y-%m-%d" %}
 
 TPs
 =======
@@ -12,6 +10,17 @@ TPs
 A continuación encontrarán las entregas que iremos planteando a lo largo de la
 materia.
 
-{: .table .table-striped}
-| **TP**       | **Código**      | **Fecha de entrega** |{% for item in site.data.trabajos %}{% assign tp = item[1] %}{% assign comienzo = tp.publicacion | date: "%Y-%m-%d" %}{% if hoy >= comienzo and hoy <= expiracion %}
-|[{{tp.id}}]({{tp.enunciado_link | relative_url}}) | [{{tp.zip}}]({{tp.zip_link}}) | {{tp.entrega}}{% endif %}{% endfor %}
+<table class="table table-striped">
+  <tbody id="tabla-trabajos">
+    <tr>
+      <td><strong>TP</strong></td>
+      <td><strong>Código</strong></td>
+      <td><strong>Fecha de publicación</strong></td>
+      <td><strong>Fecha de entrega</strong></td>
+    </tr>
+  </tbody>
+</table>
+ 
+ <h4 id="trabajo"></h4>
+ 
+ <script src="{{ '/assets/js/publicacionTPs.js' | relative_url }}"></script> 


### PR DESCRIPTION
Los TPs se ponen todos en la tabla, junto a su fecha de entrega y publicación.
Si el dia es mayor a la publicación, se habilitan los links al enunciado y zip.

![image](https://user-images.githubusercontent.com/25667102/39878620-29958dda-544f-11e8-8433-cac42f4c4e64.png)