### PR TITLE
Apuntar a releases de abb test

### DIFF
--- a/static/tps/tda/07_abb.md
+++ b/static/tps/tda/07_abb.md
@@ -59,7 +59,7 @@ const char *abb_iter_in_ver_actual(const abb_iter_t *iter);
 bool abb_iter_in_al_final(const abb_iter_t *iter);
 void abb_iter_in_destruir(abb_iter_t* iter);
 ```
-Contamos con un [script de pruebas](https://github.com/algoritmos-rw/algo2_abb_test) que pueden ejecutar para verificar que la estructura que implementaron funciona correctamente. De todas formas, al igual que en entregas anteriores, deben realizar sus propias pruebas (pueden tomar las pruebas del hash como referencia, ya que el comportamiento de ambas estructuras es muy similar).
+Contamos con un [script de pruebas](https://github.com/algoritmos-rw/algo2_abb_test/releases) que pueden ejecutar para verificar que la estructura que implementaron funciona correctamente. De todas formas, al igual que en entregas anteriores, deben realizar sus propias pruebas (pueden tomar las pruebas del hash como referencia, ya que el comportamiento de ambas estructuras es muy similar).
 
 Como siempre, deben subir el código completo a la [página de entregas de la materia]({{site.entregas}}) y también entregarlo impreso con nombre y padrón de ambos integrantes, si su corrector así lo requiere.
 


### PR DESCRIPTION
Para evitar que los alumnos que no se manejen mucho con gh se desorienten