### PR TITLE
Cambiar "no olvidar visitar" a "no olviden revisar".

### DIFF
--- a/static/06_faq.md
+++ b/static/06_faq.md
@@ -30,6 +30,6 @@ Preguntas frecuentes
 
 * [Heap](heap)
 
-* [Árbol Binario de Busqueda](abb)
+* [Árbol Binario de Búsqueda](abb)
 
 Si tenés alguna pregunta que consideras frecuente podes agregarla como un [issue](https://github.com/algoritmos-rw/algo2/issues) y la agregamos al sitio.

--- a/static/faq/abb.md
+++ b/static/faq/abb.md
@@ -1,10 +1,10 @@
 ---
 layout: page
-title: FAQ - Árbol Binario de Busqueda
+title: FAQ - Árbol Binario de Búsqueda
 permalink: /faq/abb
 ---
 
-FAQ - Árbol Binario de Busqueda
+FAQ - Árbol Binario de Búsqueda
 =========
 {:.no_toc}
 

--- a/static/faq/hash.md
+++ b/static/faq/hash.md
@@ -51,11 +51,11 @@ No. Las funciones de hashing son un tema muy extenso en la computación, y no se
 
 Para obtener el mejor rendimiento de nuestra tabla de hash, queremos que las claves esten lo mejor distribuidas posibles en la capacidad. Es decir, que reduzcamos al mínimo posible las colisiones que obtendremos. Recordemos que una colisión es cuando dos claves van a parar al mismo 'balde' de la tabla de hash, sin importar si es abierto o cerrado.
 
-A lo que nos referimos con esto es que si tenemos un hash con 5 baldes y tiene un elemento en cada uno de esos 5 baldes, la busqueda de un elemento será más rápida que si tenemos los 5 elementos sobre el mismo balde, lo cual necesita de más operaciones.
+A lo que nos referimos con esto es que si tenemos un hash con 5 baldes y tiene un elemento en cada uno de esos 5 baldes, la búsqueda de un elemento será más rápida que si tenemos los 5 elementos sobre el mismo balde, lo cual necesita de más operaciones.
 
 Por otro lado, el concepto básico de una función de hashing es el de tomar una cadena y convertirla en un número. Más alla de la implementación de la función, ese número puede ser cualquier número. Ahora, suponiendo que la cadena 'holamundo' se encripte al número '3310', pero mi tabla de hash tiene una capacidad de 30 bloques, de alguna forma tengo que reducir el 3310 a un número entre 0 y 30. ¿Cómo hago esto? Facil! Con el operador de módulo (en código, el `%`), que es el resto de la división entre dos números. En este caso, `3310 mod 30 = 10`. 
 
-Entonces, con la idea de que queremos generar la menor cantidad de colisiones posibles, y que una colisión nos sucedera cuando el aplicarle modulo a dos números distintos sobre la capacidad nos de el mismo resultado, estamos en busqueda de un número que distribuya lo mas variado posible los resultados al aplicarsele modulo.
+Entonces, con la idea de que queremos generar la menor cantidad de colisiones posibles, y que una colisión nos sucedera cuando el aplicarle modulo a dos números distintos sobre la capacidad nos de el mismo resultado, estamos en búsqueda de un número que distribuya lo mas variado posible los resultados al aplicarsele modulo.
 
 Claramente, si se hace un modulo de un multiplo de un número a otro, el resultado sera 0, ya que la división es perfecta, sin resto. 
 
@@ -78,7 +78,7 @@ Extendiendo un poco esto, con la notación `n mod d = r`, cualquier n que compar
 40 mod 16 = 8//40 es múltiplo de 20, haciendo que vaya a parar a donde ya paró el 72. Otra colisión! 
 ```
 
-Entonces, estamos en busqueda de un d que contenga la menor cantidad posible de factores, para que todo n que usemos comparta pocos factores con el, así logrando que la distribución sea variada. Y sabiendo que los números primos solo pueden dividirse por 1 o por si mismos, son un muy buen número para utilizar!
+Entonces, estamos en búsqueda de un d que contenga la menor cantidad posible de factores, para que todo n que usemos comparta pocos factores con el, así logrando que la distribución sea variada. Y sabiendo que los números primos solo pueden dividirse por 1 o por si mismos, son un muy buen número para utilizar!
 
 ```
 18 mod 7 = 4

--- a/static/tps/tda/01_tp0.md
+++ b/static/tps/tda/01_tp0.md
@@ -29,4 +29,4 @@ En la entrega de ser impresa en una hoja de papel, con su nombre y padrón, impr
 
 Además, deben subir el código a la [página de entregas de la materia]({{site.entregas}}), con el código completo.
 
-**No olvidar visitar los [primeros pasos en Linux](/algo2/faq/primeros-pasos) y las [preguntas frecuentes](/algo2/faq/).**
+**No olviden revisar los [primeros pasos en Linux](/algo2/faq/primeros-pasos) y las [preguntas frecuentes](/algo2/faq/).**

--- a/static/tps/tda/02_vector.md
+++ b/static/tps/tda/02_vector.md
@@ -40,4 +40,4 @@ Usar la misma linea provista para el tp0 para compilar. Para correr Valgrind, us
 
     valgrind --leak-check=full --track-origins=yes --show-reachable=yes ./pruebas
 
-**No olvidar visitar las [preguntas frecuentes de los TDA](/algo2/faq/tda)**
+**No olviden revisar las [preguntas frecuentes de los TDA](/algo2/faq/tda)**

--- a/static/tps/tda/04_cola.md
+++ b/static/tps/tda/04_cola.md
@@ -22,7 +22,7 @@ Deberán entregar el código en papel, con el nombre y padrón, imprimiendo el a
 
 Además, deben subir el código a la [página de entregas de la materia]({{site.entregas}}), con el código completo.
 
-**No olvidar visitar las [preguntas frecuentes de la cola](/algo2/faq/cola)**
+**No olviden revisar las [preguntas frecuentes de la cola](/algo2/faq/cola)**
 
 ---
 ### Bibliografia recomendada

--- a/static/tps/tda/05_lista.md
+++ b/static/tps/tda/05_lista.md
@@ -72,7 +72,7 @@ Al igual que en los casos anteriores, deberán entregar el código en papel, con
 
 Además, deben subir el código a la [página de entregas de la materia]({{site.entregas}}), con el código completo.
 
-**No olvidar visitar las [preguntas frecuentes de la lista enlazada](/algo2/faq/lista-enlazada)**
+**No olviden revisar las [preguntas frecuentes de la lista enlazada](/algo2/faq/lista-enlazada)**
 
 ---
 ### Bibliografia recomendada

--- a/static/tps/tda/06_hash.md
+++ b/static/tps/tda/06_hash.md
@@ -67,7 +67,7 @@ chmod +x tiempos_volumen.sh
 ./tiempos_volumen.sh ./main
 ```
 
-**No olvidar visitar las [preguntas frecuentes del hash](/algo2/faq/hash)**
+**No olviden revisar las [preguntas frecuentes del hash](/algo2/faq/hash)**
 
 ---
 ### Bibliografia recomendada

--- a/static/tps/tda/07_abb.md
+++ b/static/tps/tda/07_abb.md
@@ -63,7 +63,7 @@ Contamos con un [script de pruebas](https://github.com/algoritmos-rw/algo2_abb_t
 
 Como siempre, deben subir el código completo a la [página de entregas de la materia]({{site.entregas}}) y también entregarlo impreso con nombre y padrón de ambos integrantes, si su corrector así lo requiere.
 
-**No olvidar visitar las [preguntas frecuentes del árbol binario de busqueda](/algo2/faq/abb)**
+**No olviden revisar las [preguntas frecuentes del árbol binario de búsqueda](/algo2/faq/abb)**
 
 ---
 ### Bibliografia recomendada

--- a/static/tps/tda/08_heap.md
+++ b/static/tps/tda/08_heap.md
@@ -41,7 +41,7 @@ La función de comparación (de tipo `cmp_func_t`) debe recibir dos punteros del
 
 Como siempre, deben subir el código completo a la [página de entregas de la materia]({{site.entregas}}) y también entregarlo impreso con nombre y padrón de ambos integrantes, si su corrector así lo requiere.
 
-**No olvidar visitar las [preguntas frecuentes del heap](/algo2/faq/heap)**
+**No olviden revisar las [preguntas frecuentes del heap](/algo2/faq/heap)**
 
 ---
 ### Bibliografia recomendada


### PR DESCRIPTION
Es ligeramente más correcto y entendible. (De paso, también corregir
la falta de acento gráfico en varios ‘busqueda’.)