### PR TITLE
Mejorar el scrolling adentro de la página para respetar la historia.

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -18,10 +18,14 @@
       <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
       <script src="{{ '/assets/js/bootstrap.min.js' | relative_url }}"></script>
       <script>
-        $("#markdown-toc li a").click(function(e) {
-            e.preventDefault();
-            var aux = $(this).attr("href");
-            $('html,body').animate({scrollTop: $(aux).position().top-$("nav.navbar").height()},0);
+        // Como usamos position: fixed para la barra de navegación, el
+        // cómputo de posiciones para scroll es incorrecto (ver #89). Se
+        // puede solucionar con padding/margin falsos que se autocancelan
+        // (similar a https://stackoverflow.com/a/17130459/848301).
+        $('a[href^="#"]').each(function() {
+            $($(this).attr("href"))
+              .css("padding-top",  $("nav.navbar").height())
+              .css("margin-top",  -$("nav.navbar").height());
         });
       </script>
 


### PR DESCRIPTION
El método anterior (2d3135f: "Anchor de los indices hecho con JS para
garantizar que va a donde tiene que ir") tiene la ventaja de que solo se
ejecuta si se hace click en él, pero la desventaja de que rompe la
historia (no se puede navegar hacia atrás a la tabla de contenidos).

El método introducido ahora arregla este problema, a costa de
cambiar con anticipación el padding y márgenes de todos los elementos
afectados. (Closes: #333.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/algoritmos-rw/algo2/334)
<!-- Reviewable:end -->
