### PR TITLE
Fix display de math con KaTeX, roto con Kramdown 2.2

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -14,11 +14,12 @@
   <!-- <link rel="canonical" href="{{ page.url | replace:'index.html','' | absolute_url }}"> -->
 
   {% if page.math %}
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css"
-        crossorigin="anonymous" integrity="sha256-V8SV2MO1FUb63Bwht5Wx9x6PVHNa02gv8BgH/uH3ung=">
-  <script src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.js"
-          crossorigin="anonymous" integrity="sha256-F/Xda58SPdcUCr+xhSGz9MA2zQBPb0ASEYKohl8UCHc="></script>
-  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/mathtex-script-type.min.js"
-          crossorigin="anonymous" integrity="sha256-b8diVEOgPDxUp0CuYCi7+lb5xIGcgrtIdrvE8d/oztQ="></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.css"
+        crossorigin="anonymous" integrity="sha384-AfEj0r4/OFrOo5t7NnNe46zW/tFgW6x/bCJG8FqQCEo3+Aro6EYUG4+cU+KJWu/X">
+  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.js"
+          crossorigin="anonymous" integrity="sha384-g7c+Jr9ZivxKLnZTDUhnkOnsh30B4H0rpLUpJ4jAIKs4fnJI+sEnkvrMWph2EDg4"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/contrib/auto-render.min.js"
+          crossorigin="anonymous" integrity="sha384-mll67QQFJfxn0IYznZYonOWZ644AWYC+Pt2cHqMaRhXVrursRwvLnLaebdGIlYNa"
+          onload="renderMathInElement(document.body);"></script>
   {% endif %}
 </head>


### PR DESCRIPTION
Github Pages v207 rompe nuestro rendering de math con KaTeX
(github/pages-gem#705), porque la nueva versión de Kramdown
cambia la sintaxis MathJax que emite (gettalong/kramdown#626).

El fix es usar directamente al auto-render.js de KaTeX, en lugar
del script anterior que usábamos (mathtex-script-type.js).

De paso, actualizar a KaTeX 0.12.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/algoritmos-rw/algo2/360)
<!-- Reviewable:end -->
