### PR TITLE
Se renombran archivos de pruebas de las entregas

### DIFF
--- a/tda/cola.md
+++ b/tda/cola.md
@@ -14,9 +14,9 @@ La entrega es muy similar a la realizada para el TDA Pila.  Excepto que la funci
 
 La cola debe ser enlazada, es decir que en lugar de usar un arreglo, usa nodos enlazados, de los cuales se desencola el primero y se encola a continuación del último. Por tanto, se debe implementar solamente con punteros, y no se debe guardar en un campo el tamaño de la cola.
 
-Deben entregar un archivo `pruebas_alumno.c` que haga las correspondientes pruebas unitarias. Además de las pruebas obligatorias análogas a las pedidas para la [pila](pila.md), también tienen que incluir unas pruebas para probar la destrucción con y sin funciones de destrucción de los elementos.
+Deben entregar un archivo `pruebas_cola.c` que haga las correspondientes pruebas unitarias. Además de las pruebas obligatorias análogas a las pedidas para la [pila](pila.md), también tienen que incluir unas pruebas para probar la destrucción con y sin funciones de destrucción de los elementos.
 
-Deberán entregar el código en papel, con el nombre y padrón, imprimiendo el archivo `cola.c` y el archivo `pruebas_alumno.c`.
+Deberán entregar el código en papel, con el nombre y padrón, imprimiendo el archivo `cola.c` y el archivo `pruebas_cola.c`.
 
 Además, deben subir el código a la [página de entregas de la materia]({{site.entregas}}), con el código completo.
 

--- a/tda/lista.md
+++ b/tda/lista.md
@@ -66,7 +66,7 @@ Las pruebas deben incluir los casos básicos de TDA similares a los contemplados
 1. Otros casos borde que pueden encontrarse al utilizar el iterador externo.
 Y los casos con / sin corte del iterador interno.
 
-Al igual que en los casos anteriores, deberán entregar el código en papel, con el nombre y padrón y el nombre del ayudante correspondiente, imprimiendo los archivos `lista.h`, `lista.c` y `pruebas_alumno.c`.
+Al igual que en los casos anteriores, deberán entregar el código en papel, con el nombre y padrón y el nombre del ayudante correspondiente, imprimiendo los archivos `lista.h`, `lista.c` y `pruebas_lista.c`.
 
 Además, deben subir el código a la [página de entregas de la materia]({{site.entregas}}), con el código completo.
 

--- a/tda/pila.md
+++ b/tda/pila.md
@@ -24,7 +24,7 @@ struct pila {
 };
 ```
 
-Además de `pila.c`, tienen que entregar otro archivo `pruebas_alumno.c`, que contenga las pruebas unitarias para verificar que la pila funciona correctamente, y que al ejecutarlo puede verificarse que todo funciona bien y no se pierde memoria. El archivo `pruebas_alumno.c` debe contener una función llamada `pruebas_pila_alumno()` que ejecute todas las pruebas. Se permite (y recomienda) usar funciones auxiliares.
+Además de `pila.c`, tienen que entregar otro archivo `pruebas_pila.c`, que contenga las pruebas unitarias para verificar que la pila funciona correctamente, y que al ejecutarlo puede verificarse que todo funciona bien y no se pierde memoria. El archivo `pruebas_pila.c` debe contener una función llamada `pruebas_pila_alumno()` que ejecute todas las pruebas. Se permite (y recomienda) usar funciones auxiliares.
 
 Las pruebas deberán verificar que:
 1. Se pueda crear y destruir correctamente la estructura.
@@ -47,7 +47,7 @@ Para compilar y verificar las pruebas:
 
         valgrind --leak-check=full --track-origins=yes --show-reachable=yes ./pruebas
 
-Al igual que en los casos anteriores, deberán entregar el código en papel, con el nombre y padrón, imprimiendo el archivo `pila.c` y el archivo `pruebas_alumno.c`.
+Al igual que en los casos anteriores, deberán entregar el código en papel, con el nombre y padrón, imprimiendo el archivo `pila.c` y el archivo `pruebas_pila.c`.
 Además, deben subir el código a la [página de entregas de la materia]({{site.entregas}}), con el código completo.
 
 ---


### PR DESCRIPTION
Siguiendo el cambio en algoritmos-rw/algo2_skel#174, en pila.md
renombramos pruebas_alumno.c → pruebas_pila.c, y hacemos lo mismo
en cola.md y lista.md.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/algoritmos-rw/algo2/361)
<!-- Reviewable:end -->
