### PR TITLE
No permitir strstr en strutil

### DIFF
--- a/tps/2020_2/tp1.md
+++ b/tps/2020_2/tp1.md
@@ -27,12 +27,13 @@ El trabajo práctico número 1 tiene fecha de entrega para el día **{{fecha}}**
 
 Se pide implementar las funciones de manejo que cadenas que se describen a continuación. Adjunto en el [sitio de descargas]({{site.skel}}) se puede encontrar un archivo _strutil.h_ con todos sus prototipos.
 
-Para la implementación de estas funciones no se permite el uso de TDAs. Sí se permite, no obstante, el uso de las funciones de la biblioteca estándar de C [string.h] (excepto `strtok`). Se recomiendan, en particular:
+Para la implementación de estas funciones no se permite el uso de TDAs. Sí se permite, no obstante, el uso de las funciones de la biblioteca estándar de C [string.h] (excepto `strtok` y `strstr`). Se recomiendan, en particular:
 
- - `strlen`
+ - `strlen`, `strchr`
  - `strcpy`/`strncpy`
  - `strdup`/`strndup`
  - `snprintf`
+
 
 [string.h]: http://pubs.opengroup.org/onlinepubs/7908799/xsh/string.h.html
 


### PR DESCRIPTION
strchr es una mejor alternativa que no necesita la construcción
artificial de un `char[2]`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/algoritmos-rw/algo2/371)
<!-- Reviewable:end -->
