### PR TITLE
Corrección de enunciado

### DIFF
--- a/tps/2021_2/tp1.md
+++ b/tps/2021_2/tp1.md
@@ -47,7 +47,7 @@ Con las siguientes consideraciones:
     parámetro no es un número) se deberá imprimir por salida de error estándar `Error: Cantidad erronea de parametros`.
   - En caso de contar con parámetro para el archivo, en caso que hubiera un error para usar el archivo
     para lectura (no existe, no hay permisos, etc...), se deberá escribir por salida de error estándar
-    `Error: Error: archivo fuente inaccesible`.
+    `Error: archivo fuente inaccesible`.
   - No se podrá considerar que entra todo el archivo a dividir en memoria.
   
 


### PR DESCRIPTION
Al entregar el TP1 y verificar las pruebas he notado que el corrector en la prueba 05 (y probablemente en otras tambien) compara el stderr con la linea `Error: archivo fuente inaccesible` mientras que en el enunciado se pide que utilicemos `Error: Error: archivo fuente inaccesible` como mensaje en stderr. Esto talvez sea algún tipo de typo?