### PR TITLE
Ajustar dirección web del sitio de descargas al nuevo repositorio

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,7 +7,7 @@ description: >
 baseurl: "/algo2"
 entregas: "https://algoritmos-rw.dijkstra.ar/entregas/"
 notas: "https://algoritmos-rw.dijkstra.ar/notas/"
-skel: "https://algoritmos-rw.github.io/algo2_skel"
+skel: "https://algoritmos-rw.github.io/descargas"
 algo1: "https://algoritmos1rw.ddns.net/"
 # url: "https://algoritmos-rw.github.io"
 


### PR DESCRIPTION
Ver: https://github.com/algoritmos-rw/algo2_skel/commit/b7faeac38911.

-----

@mbuchwald: Es más cómodo que nos vuelvan a dar la versión paga de Github Teams; pero si no lo hacen, o no queremos esperar, lo he arreglado con una URL nueva (ver el commit referenciado arriba).