### PR TITLE
Fix typo enunciado tp3 comando reducir_caminos

### DIFF
--- a/tps/2022_2/tp3.md
+++ b/tps/2022_2/tp3.md
@@ -160,7 +160,7 @@ visitar para ver todas las rutas una vez y volver al origen. Además guardará u
 	Los resultados podrían ser otros, pero siempre tienen que aparecer la totalidad de aristas (y, por lo tanto, el tiempo total siempre debería ser el mismo)
 
 * `reducir_caminos destino.pj`: nos crea un archivo pajek (formáto idéntico al archivo de ciudades
-inicial, pero únicamente con los caminos estrictamente necesarios. Al finalizar, debe imprimir por salida
+inicial, pero únicamente con los caminos estrictamente necesarios). Al finalizar, debe imprimir por salida
 estándar la suma de los pesos de las aristas del árbol, en formato `"Peso total: ..."`. Para el archivo de ejemplo, el peso del árbol de tendido mínimo debe ser 26.
 
 Como se indica antes, para los comandos `ir` y `viaje`, será necesario además exportar un archivo KML a la ruta indicada por


### PR DESCRIPTION
Solamente agregue un paréntesis en el comando reducir_caminos.

- Respecto a este ultimo párrafo antes de "Archivos KML" Como se indica antes, para los comandos `ir` y `viaje`, será necesario además exportar un archivo KML a la ruta indicada por parámetro al invocarse el programa. Se incluye, entre los archivos disponibles a descargar, un ejemplo para el camino mínimo entre Doha y Uum bab.

En los archivos a descargar no hay ningún ejemplo de camino mínimo entre Doha y Uum bab,  solo hay 3 archivos, mapa_ejemplo.kml, qatar.pj y recomendaciones_ejemplo.csv, de todas formas el comando "ir desde, hasta, archivo" ya tiene el ejemplo

"exportar un kml a la ruta especificada por párametro", no es lo mismo guardar el archivo en esa ruta?, "al invocarse el programa"?, no debería ser al invocarse el comando?